### PR TITLE
Fixes #47 Wrong return type getWeatherIcon function and adde return statement in rf::init_rf()

### DIFF
--- a/BaseStation/DisplayData.cpp
+++ b/BaseStation/DisplayData.cpp
@@ -2,7 +2,7 @@
     Written by Stig B. Sivertsen
     sbsivertsen@gmail.com
     https://github.com/datamann/GA-weather-station
-    08.12.2020
+    11.07.2021
     @see The GNU Public License (GPL) Version 3
 */
 
@@ -17,7 +17,7 @@
  * String cityid[3] = {"3159016","1711146"}; // Drammen, Ilagan
 */
 
-String RemoteSensorLocation = "Skogliveien 14";
+String RemoteSensorLocation = "Verven 30";
 
 DisplayData::DisplayData() {
   init_LCD();
@@ -242,7 +242,7 @@ void DisplayData::drawFewClouds(String pageid)
   DisplayData::endNextionCommand(); 
 };
 
-const char* DisplayData::getWeatherIcon(int id, String pageid)
+void DisplayData::getWeatherIcon(int id, String pageid)
 {
  switch(id)
  {

--- a/BaseStation/DisplayData.h
+++ b/BaseStation/DisplayData.h
@@ -48,7 +48,7 @@ class DisplayData {
     void printToLCD(String field, String data);
     void updateTimeLCD(String Time);
     void updateDateLCD(String Day, String Date);
-    const char* getWeatherIcon(int id, String pageid);
+    void getWeatherIcon(int id, String pageid);
     void readLCDData(String* cityid, String Day, String Date, String Time, WeatherData City1, WeatherData City2, SensorData sensorData, String IP);
   
   private:

--- a/BaseStation/rf.h
+++ b/BaseStation/rf.h
@@ -20,4 +20,5 @@
 bool init_rf() {
   bool status = false;
   status = rf.init();
+  return status;
 }

--- a/BaseStation/wifi.h
+++ b/BaseStation/wifi.h
@@ -32,6 +32,7 @@ WiFiClient init_Wifi() {
 #endif
 #ifdef ESP8266
   WiFi.mode(WIFI_STA);
+  WiFi.softAPdisconnect(true);
   WiFi.begin(ssid, password);
   WiFiClient client;
 #endif


### PR DESCRIPTION
Fixes #47

ESP8266 crashed for some reason because of the return type and missing return statement.

Change return type
from:
const char* getWeatherIcon(int id, String pageid);

to:
void getWeatherIcon(int id, String pageid);

Added:
rf::init_rf()
return status;